### PR TITLE
Set PV on ostree-basic-pkg from git hash

### DIFF
--- a/meta-ivi-common/recipes-devtools/ostree-basic-pkg/ostree-basic-pkg.bb
+++ b/meta-ivi-common/recipes-devtools/ostree-basic-pkg/ostree-basic-pkg.bb
@@ -7,6 +7,8 @@ SRC_URI = "git://github.com/advancedtelematic/ostree-basic-pkg.git;protocol=ssh;
 SRCREV = "${AUTOREV}"
 S = "${WORKDIR}/git"
 
+PV = "1.0+${SRCPV}"
+
 FILES_${PN} = " \
                 ${bindir}/otbpkg \
               "
@@ -19,4 +21,3 @@ do_install() {
   install -m 0755 ${S}/otbpkg ${D}${bindir}
 
 }
-


### PR DESCRIPTION
This fixes a bug where ostree-basic-pkg will not get rebuilt when the source
git repository gets updated.
